### PR TITLE
Update alias generation

### DIFF
--- a/env-hooks/99.sergio_functions.bash
+++ b/env-hooks/99.sergio_functions.bash
@@ -8,7 +8,7 @@ for launch_file in ${launch_files}; do
     launch_file_name=$(echo ${launch_file##*/} | cut -d"." -f1)
     name=${bringup_name//_/-}-${launch_file_name//_/-}
     if [[ $launch_file == *"state_machines"* ]]; then
-        eval "${name}() { export ROBOT_BRINGUP_PATH=${package_path} && rosnode kill /state_machine && roslaunch ${launch_file} \$@; }"
+        eval "${name}() { export ROBOT_BRINGUP_PATH=${package_path} && rosnode kill /state_machine; roslaunch ${launch_file} \$@; }"
     else
         eval "${name}() { export ROBOT_BRINGUP_PATH=${package_path} && roslaunch ${launch_file} \$@; }"
     fi


### PR DESCRIPTION
Similar to https://github.com/tue-robotics/amigo_bringup/commit/bd788e22a09dec34428b6fa2f0df884e5f49466c

Because rosnode kill doesn't continue anymore, when the node doesn't exist.